### PR TITLE
fix: Set database image as mysql in with-mysql example

### DIFF
--- a/examples/with-mysql/docker-compose.yml
+++ b/examples/with-mysql/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - external-pod
 
   mysql:
-    image: library/mariadb:latest
+    image: mysql:latest
     environment:
       MYSQL_DATABASE: "dolibarr"
       MYSQL_USER: "dolibarr"


### PR DESCRIPTION
In with-mysql example the docker image was mariadb.